### PR TITLE
Remove password length limit in validator

### DIFF
--- a/example/lib/token_page.dart
+++ b/example/lib/token_page.dart
@@ -66,8 +66,6 @@ class _TokenPageState extends State<TokenPage> {
                 validator: (input) {
                   if (input == null || input.isEmpty) {
                     return 'Password cannot be empty';
-                  } else if (input.length < 6) {
-                    return 'Password must be longer than 5 characters';
                   }
                   return null;
                 },


### PR DESCRIPTION
To enable any password length while getting a token, please remove the "else if" in validator under decoration